### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wobkobi/ChatGPT-Discord-Bot/security/code-scanning/6](https://github.com/wobkobi/ChatGPT-Discord-Bot/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimum required permissions for the workflow. Since the workflow only performs read operations (e.g., checking out code and installing dependencies), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has only the permissions necessary to complete the tasks in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
