### PR TITLE
Add commands to change bot avatar and username

### DIFF
--- a/src/commands/setavatar.ts
+++ b/src/commands/setavatar.ts
@@ -1,0 +1,70 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { getRequired } from "../utils/env.js";
+import logger from "../utils/logger.js";
+
+const OWNER_ID = getRequired("OWNER_ID");
+
+/**
+ * /setavatar
+ * @description Change the bot’s avatar image (Owner only).
+ *  Only the application owner may run this. Pass an image file as the “avatar” option.
+ */
+export const data = new SlashCommandBuilder()
+  .setName("setavatar")
+  .setDescription("Set the bot’s avatar image (Owner only)")
+  .addAttachmentOption((opt) =>
+    opt
+      .setName("avatar")
+      .setDescription("Image file to set as the new bot avatar")
+      .setRequired(true)
+  );
+
+/**
+ * Executes the /setavatar command.
+ * @param interaction – The ChatInputCommandInteraction context.
+ * @returns Promise<void>
+ */
+export async function execute(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const userId = interaction.user.id;
+  if (userId !== OWNER_ID) {
+    await interaction.reply({
+      content: "🚫 You are not allowed to change my avatar.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const attachment = interaction.options.getAttachment("avatar", true);
+  if (!attachment.contentType?.startsWith("image/")) {
+    await interaction.reply({
+      content: "❌ Please provide a valid image file.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // Defer an ephemeral reply to give time for fetching and updating
+  await interaction.deferReply({ ephemeral: true });
+  try {
+    // Node 18+ has global fetch; otherwise install node-fetch
+    const res = await fetch(attachment.url);
+    const arrayBuffer = await res.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    await interaction.client.user!.setAvatar(buffer);
+    logger.info(
+      `[setavatar] Bot avatar updated successfully by owner ${userId}`
+    );
+
+    // Edit the deferred reply; no ephemeral flag needed here
+    await interaction.editReply({ content: "✅ Avatar updated successfully." });
+  } catch (err) {
+    logger.error("[setavatar] Failed to set avatar:", err);
+    // Edit the deferred reply; no ephemeral flag needed here
+    await interaction.editReply({
+      content: "⚠️ Something went wrong while updating my avatar.",
+    });
+  }
+}

--- a/src/commands/setname.ts
+++ b/src/commands/setname.ts
@@ -1,0 +1,65 @@
+// src/commands/setname.ts
+
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { getRequired } from "../utils/env.js";
+import logger from "../utils/logger.js";
+
+const OWNER_ID = getRequired("OWNER_ID");
+
+/**
+ * /setname
+ * @description Change the bot’s global username (Owner only).
+ *  Only the application owner may run this. Username length must be ≤ 32 chars.
+ */
+export const data = new SlashCommandBuilder()
+  .setName("setname")
+  .setDescription("Set the bot’s username (Owner only)")
+  .addStringOption((opt) =>
+    opt
+      .setName("name")
+      .setDescription("New username for the bot (max 32 characters)")
+      .setRequired(true)
+  );
+
+/**
+ * Executes the /setname command.
+ * @param interaction – The ChatInputCommandInteraction context.
+ */
+export async function execute(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const userId = interaction.user.id;
+  if (userId !== OWNER_ID) {
+    await interaction.reply({
+      content: "🚫 You are not allowed to change my name.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const newName = interaction.options.getString("name", true).trim();
+  if (newName.length > 32) {
+    await interaction.reply({
+      content: "❌ Name must be 32 characters or fewer.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  try {
+    await interaction.client.user!.setUsername(newName);
+    logger.info(
+      `[setname] Bot username changed to "${newName}" by owner ${userId}`
+    );
+    await interaction.reply({
+      content: `✅ Username updated to **${newName}**.`,
+      ephemeral: true,
+    });
+  } catch (err) {
+    logger.error("[setname] Failed to set username:", err);
+    await interaction.reply({
+      content: "⚠️ Something went wrong while updating my name.",
+      ephemeral: true,
+    });
+  }
+}


### PR DESCRIPTION
- Implement `/setavatar` command for changing the bot’s avatar (owner only).
- Implement `/setname` command for changing the bot’s username (owner only).
- Include validation for image file type and username length.
- Log successful changes and handle errors appropriately.