### PR TITLE
feat: v2.1.1 - improved reply pipeline, guild-scoped commands, and tooling modernisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@discordjs/rest": "^2.6.1",
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1433,9 +1433,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -4304,9 +4304,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

- Replaced `ts-node` with `tsx` as the dev runner and added `tsc-alias` to correctly resolve TypeScript path aliases in the compiled output, so the built bot starts without module resolution errors.
- Restricted `/setcooldown` and `/setinterjection` commands to guild contexts only, preventing confusing DM interactions where guild-scoped settings have no effect.
- Refactored the reply pipeline to fix prompt assembly bugs and tighten imports, resulting in more reliable AI responses and a cleaner module graph.
- Overhauled GitHub Actions workflows and Dependabot config to enforce `npm ci`, auto-merge safe dependency bumps, and streamline the CI build step.
- Cleaned up example config files and bumped all transitive dependencies to their latest compatible versions.

## Test plan

- [ ] Run `npm run build` and confirm it exits cleanly with no type errors.
- [ ] Start the bot with `npm run dev` and verify it connects to Discord without module-not-found errors.
- [ ] Run `/setcooldown` and `/setinterjection` in a DM and confirm they are rejected with an appropriate message.
- [ ] Send a message the bot should respond to in a guild channel and confirm a coherent reply is generated.
- [ ] Check GitHub Actions on this PR passes the build workflow.