### PR TITLE
fix: skip ANSI colorize when stdout is not a TTY

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -41,9 +41,9 @@ const commonFormat = combine(
   logFormat,
 );
 
-// Console transport with colourised output for readability
+// Console transport: colourised only when stdout is a real TTY
 const consoleTransport = new winston.transports.Console({
-  format: combine(colorize({ all: true }), commonFormat),
+  format: process.stdout.isTTY ? combine(colorize({ all: true }), commonFormat) : commonFormat,
 });
 
 /**


### PR DESCRIPTION
## Summary
- Skip ANSI colour codes in the Winston console transport when `stdout` is not a real TTY, preventing escape sequences from appearing in piped output, log files, and CI logs

## Test plan
- [ ] Run bot normally in a terminal — colourised output should appear as before
- [ ] Pipe output or run in CI — no ANSI escape sequences in the output