### PR TITLE
chore: clean stale build output in build script and reuse it in start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dependencies": {
         "@discordjs/rest": "^2.6.3",
         "@giphy/js-fetch-api": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "chatgpt",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "node -e \"fs.rmSync('build',{recursive:true,force:true,maxRetries:10,retryDelay:200});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",
     "dev": "tsx watch src/index.ts",
     "format": "prettier --write \"**/*.{js,mjs,cjs,ts,md,json,yml,yaml}\"",
     "lint": "eslint \"src/**/*.{js,ts}\" --fix",
     "prepare": "simple-git-hooks",
-    "start": "tsc && tsc-alias && node build/index.js",
+    "start": "npm run build && node build/index.js",
     "typecheck": "tsc --noEmit"
   },
   "simple-git-hooks": {


### PR DESCRIPTION
## Summary
- build script now removes the build/ directory and tsconfig.tsbuildinfo before running tsc && tsc-alias, so stale compiled files no longer linger between builds
- start script now runs npm run build instead of duplicating the tsc && tsc-alias steps
- restored the scripts wrapper in package.json that was accidentally dropped during the edit
- bumped version to 2.1.5 and synced package-lock.json