### PR TITLE
refactor: v2.2.1 - drop .js from internal imports, bump pinned GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Keeps the `uses:` tags in .github/workflows current. Without this, pinned
+  # actions silently fall behind and the runner warns about their declared
+  # Node runtime (node20 actions forced onto node24).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge Dependabot PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "@discordjs/rest": "^2.6.3",
         "@giphy/js-fetch-api": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -3,18 +3,18 @@
  * @description Slash command to privately ask the AI assistant a question.
  */
 
-import { generateReply } from "@/services/replyService.js";
-import { updateUserMemory } from "@/store/userMemory.js";
-import type { Block, ChatMessage } from "@/types/index.js";
-import { getRequired } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+import { generateReply } from "@/services/replyService";
+import { updateUserMemory } from "@/store/userMemory";
+import type { Block, ChatMessage } from "@/types/index";
+import { getRequired } from "@/utils/env";
+import logger from "@/utils/logger";
 import {
   getCooldownConfig,
   getCooldownContext,
   isCooldownActive,
   manageCooldown,
-} from "@/utils/rateControl.js";
-import { extractInputs } from "@/utils/urlExtractor/index.js";
+} from "@/utils/rateControl";
+import { extractInputs } from "@/utils/urlExtractor/index";
 import {
   ChatInputCommandInteraction,
   Collection,

--- a/src/commands/setCooldown.ts
+++ b/src/commands/setCooldown.ts
@@ -9,10 +9,10 @@ import {
   defaultInterjectionRate,
   guildConfigs,
   saveGuildConfigs,
-} from "@/config/index.js";
-import { GuildConfig } from "@/types/guild.js";
-import { getRequired } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+} from "@/config/index";
+import { GuildConfig } from "@/types/guild";
+import { getRequired } from "@/utils/env";
+import logger from "@/utils/logger";
 import {
   ChatInputCommandInteraction,
   InteractionContextType,

--- a/src/commands/setbot.ts
+++ b/src/commands/setbot.ts
@@ -3,8 +3,8 @@
  * @description Slash command to change the bot's username and/or avatar image. Owner only.
  */
 
-import { getRequired } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+import { getRequired } from "@/utils/env";
+import logger from "@/utils/logger";
 import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 
 const OWNER_ID = getRequired("OWNER_ID");

--- a/src/commands/setinterjection.ts
+++ b/src/commands/setinterjection.ts
@@ -9,9 +9,9 @@ import {
   defaultInterjectionRate,
   guildConfigs,
   saveGuildConfigs,
-} from "@/config/index.js";
-import { getRequired } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+} from "@/config/index";
+import { getRequired } from "@/utils/env";
+import logger from "@/utils/logger";
 import {
   ChatInputCommandInteraction,
   InteractionContextType,

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -3,8 +3,8 @@
  * @description Slash command to safely shut down the bot; restricted to the owner only.
  */
 
-import { getRequired } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+import { getRequired } from "@/utils/env";
+import logger from "@/utils/logger";
 import { ChatInputCommandInteraction, MessageFlags, SlashCommandBuilder } from "discord.js";
 
 /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,9 +3,9 @@
  * @description Defines, loads and persists per-guild settings: cooldown configuration and interjection rate.
  */
 
-import { DATA_DIR, GUILD_CONFIG_FILE } from "@/config/paths.js";
-import { GuildConfig, GuildCooldownConfig } from "@/types/guild.js";
-import logger from "@/utils/logger.js";
+import { DATA_DIR, GUILD_CONFIG_FILE } from "@/config/paths";
+import { GuildConfig, GuildCooldownConfig } from "@/types/guild";
+import logger from "@/utils/logger";
 import fs from "fs/promises";
 
 /** Default cooldown: on, 2.5 s, per-user. */

--- a/src/controllers/messageController.ts
+++ b/src/controllers/messageController.ts
@@ -4,27 +4,27 @@
  *   updates long-term memory, triggers AI reply generation, and persists chat state.
  */
 
-import { isBotReady } from "@/index.js";
-import { cloneUserId } from "@/services/characterService.js";
-import { generateReply } from "@/services/replyService.js";
-import { updateCloneMemory } from "@/store/cloneMemory.js";
-import { updateUserMemory } from "@/store/userMemory.js";
-import { ConversationContext } from "@/types/chat.js";
+import { isBotReady } from "@/index";
+import { cloneUserId } from "@/services/characterService";
+import { generateReply } from "@/services/replyService";
+import { updateCloneMemory } from "@/store/cloneMemory";
+import { updateUserMemory } from "@/store/userMemory";
+import { ConversationContext } from "@/types/chat";
 import {
   createChatMessage,
   replaceEmojiShortcodes,
   summariseConversation,
-} from "@/utils/discordHelpers.js";
-import { loadConversations, saveConversations } from "@/utils/fileUtils.js";
-import logger from "@/utils/logger.js";
+} from "@/utils/discordHelpers";
+import { loadConversations, saveConversations } from "@/utils/fileUtils";
+import logger from "@/utils/logger";
 import {
   getCooldownConfig,
   getCooldownContext,
   getInterjectionChance,
   isCooldownActive,
   manageCooldown,
-} from "@/utils/rateControl.js";
-import { extractInputs } from "@/utils/urlExtractor/index.js";
+} from "@/utils/rateControl";
+import { extractInputs } from "@/utils/urlExtractor/index";
 import { Client, Message } from "discord.js";
 import OpenAI from "openai";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,12 @@
  * loads per-guild configurations, sets up message and interaction handlers, and manages graceful shutdown.
  */
 
-import { loadGuildConfigs } from "@/config/index.js";
-import { handleNewMessage, run } from "@/controllers/messageController.js";
-import { initialiseCloneMemory } from "@/store/cloneMemory.js";
-import { initialiseUserMemory } from "@/store/userMemory.js";
-import { getRequired, initialiseEnv } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+import { loadGuildConfigs } from "@/config/index";
+import { handleNewMessage, run } from "@/controllers/messageController";
+import { initialiseCloneMemory } from "@/store/cloneMemory";
+import { initialiseUserMemory } from "@/store/userMemory";
+import { getRequired, initialiseEnv } from "@/utils/env";
+import logger from "@/utils/logger";
 import { REST } from "@discordjs/rest";
 import { Routes } from "discord-api-types/v10";
 import {

--- a/src/services/characterService.ts
+++ b/src/services/characterService.ts
@@ -3,9 +3,9 @@
  * @description Loads persona configuration and builds system prompts and metadata for the AI.
  */
 
-import { userMemory } from "@/store/userMemory.js";
-import { PersonaConfig } from "@/types/persona.js";
-import logger from "@/utils/logger.js";
+import { userMemory } from "@/store/userMemory";
+import { PersonaConfig } from "@/types/persona";
+import logger from "@/utils/logger";
 import { readFileSync } from "fs";
 import { DateTime } from "luxon";
 import { createRequire } from "module";

--- a/src/services/replyService.ts
+++ b/src/services/replyService.ts
@@ -10,17 +10,17 @@ import {
   getCharacterDescription,
   getSystemMetadata,
   markdownGuide,
-} from "@/services/characterService.js";
-import { cloneMemory } from "@/store/cloneMemory.js";
-import { userMemory } from "@/store/userMemory.js";
-import { Block, ChatCompletionBlockMessage } from "@/types/block.js";
-import { ChatMessage } from "@/types/chat.js";
-import { applyDiscordMarkdownFormatting } from "@/utils/discordHelpers.js";
-import { getOptional, getRequired } from "@/utils/env.js";
-import { loadUserMemory } from "@/utils/fileUtils.js";
-import { hasUnresolvedGif, resolveGifLinks, resolveGifPlaceholders } from "@/utils/gifResolver.js";
-import { renderMathToPng } from "@/utils/latexRenderer.js";
-import logger from "@/utils/logger.js";
+} from "@/services/characterService";
+import { cloneMemory } from "@/store/cloneMemory";
+import { userMemory } from "@/store/userMemory";
+import { Block, ChatCompletionBlockMessage } from "@/types/block";
+import { ChatMessage } from "@/types/chat";
+import { applyDiscordMarkdownFormatting } from "@/utils/discordHelpers";
+import { getOptional, getRequired } from "@/utils/env";
+import { loadUserMemory } from "@/utils/fileUtils";
+import { hasUnresolvedGif, resolveGifLinks, resolveGifPlaceholders } from "@/utils/gifResolver";
+import { renderMathToPng } from "@/utils/latexRenderer";
+import logger from "@/utils/logger";
 import OpenAI, { APIError } from "openai";
 import { ChatCompletionMessageParam } from "openai/resources/chat";
 

--- a/src/store/cloneMemory.ts
+++ b/src/store/cloneMemory.ts
@@ -3,10 +3,10 @@
  * @description Manages the clone memory store: logs interactions for the cloned user persona and persists them to disk.
  */
 
-import { GeneralMemoryEntry } from "@/types/memory.js";
-import { loadCloneMemory, saveCloneMemory } from "@/utils/fileUtils.js";
-import logger from "@/utils/logger.js";
-import { trimMemory } from "@/utils/trimMemory.js";
+import { GeneralMemoryEntry } from "@/types/memory";
+import { loadCloneMemory, saveCloneMemory } from "@/utils/fileUtils";
+import logger from "@/utils/logger";
+import { trimMemory } from "@/utils/trimMemory";
 
 /** In-memory cache of clone memory entries, keyed by Discord user ID. */
 export const cloneMemory = new Map<string, GeneralMemoryEntry[]>();

--- a/src/store/userMemory.ts
+++ b/src/store/userMemory.ts
@@ -3,10 +3,10 @@
  * @description Manages long-term memory entries for regular users, stored in-memory and persisted to disk.
  */
 
-import { GeneralMemoryEntry } from "@/types/memory.js";
-import { loadUserMemory, saveUserMemory } from "@/utils/fileUtils.js";
-import logger from "@/utils/logger.js";
-import { trimMemory } from "@/utils/trimMemory.js";
+import { GeneralMemoryEntry } from "@/types/memory";
+import { loadUserMemory, saveUserMemory } from "@/utils/fileUtils";
+import logger from "@/utils/logger";
+import { trimMemory } from "@/utils/trimMemory";
 
 /** In-memory cache of user memory entries, keyed by Discord user ID. */
 export const userMemory = new Map<string, GeneralMemoryEntry[]>();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 // src/types/index.ts
-export * from "@/types/block.js";
-export * from "@/types/chat.js";
-export * from "@/types/guild.js";
-export * from "@/types/memory.js";
-export * from "@/types/persona.js";
+export * from "@/types/block";
+export * from "@/types/chat";
+export * from "@/types/guild";
+export * from "@/types/memory";
+export * from "@/types/persona";

--- a/src/utils/discordHelpers.ts
+++ b/src/utils/discordHelpers.ts
@@ -5,8 +5,8 @@
  *   and stripping URL queries.
  */
 
-import { ChatMessage, ConversationContext } from "@/types/chat.js";
-import logger from "@/utils/logger.js";
+import { ChatMessage, ConversationContext } from "@/types/chat";
+import logger from "@/utils/logger";
 import { Guild, Message } from "discord.js";
 
 /**

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -3,11 +3,11 @@
  * @description Handles encryption, directory management, and generic data persistence for memory and conversations.
  */
 
-import { CLONE_MEM_DIR, CONV_DIR, USER_MEM_DIR } from "@/config/paths.js";
-import { ChatMessage, ConversationContext } from "@/types/chat.js";
-import { GeneralMemoryEntry } from "@/types/memory.js";
-import { getRequired } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+import { CLONE_MEM_DIR, CONV_DIR, USER_MEM_DIR } from "@/config/paths";
+import { ChatMessage, ConversationContext } from "@/types/chat";
+import { GeneralMemoryEntry } from "@/types/memory";
+import { getRequired } from "@/utils/env";
+import logger from "@/utils/logger";
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypto";
 import { existsSync } from "fs";
 import fs from "fs/promises";

--- a/src/utils/gifResolver.ts
+++ b/src/utils/gifResolver.ts
@@ -3,8 +3,8 @@
 // Tenor's API was discontinued, so Giphy is the only search backend; inbound tenor.com
 // links from users are handled separately in urlExtractor/extractGifs.ts.
 
-import { getOptional } from "@/utils/env.js";
-import logger from "@/utils/logger.js";
+import { getOptional } from "@/utils/env";
+import logger from "@/utils/logger";
 import { GifsResult, GiphyFetch, Rating } from "@giphy/js-fetch-api";
 
 /** Rendition set attached to a Giphy result; `@giphy/js-types` is not a direct dependency. */

--- a/src/utils/latexRenderer.ts
+++ b/src/utils/latexRenderer.ts
@@ -4,8 +4,8 @@
  *   with deterministic disk caching based on content hashes.
  */
 
-import { OUTPUT_DIR } from "@/config/paths.js";
-import logger from "@/utils/logger.js";
+import { OUTPUT_DIR } from "@/config/paths";
+import logger from "@/utils/logger";
 import { createHash } from "crypto";
 import { promises as fs } from "fs";
 import { liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor.js";

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,8 +5,8 @@
  *   Uses timestamped formatting, error stack inclusion, and emits an audible bell on error entries.
  */
 
-import { LOGS_DIR, LOGS_ERROR_DIR } from "@/config/paths.js";
-import { getOptional, initialiseEnv } from "@/utils/env.js";
+import { LOGS_DIR, LOGS_ERROR_DIR } from "@/config/paths";
+import { getOptional, initialiseEnv } from "@/utils/env";
 import fs from "fs";
 import { TransformableInfo } from "logform";
 import path from "path";

--- a/src/utils/rateControl.ts
+++ b/src/utils/rateControl.ts
@@ -3,9 +3,9 @@
  * @description Utilities for managing per-guild message cooldowns and interjection probabilities.
  */
 
-import { defaultCooldownConfig, defaultInterjectionRate, guildConfigs } from "@/config/index.js";
-import { GuildConfig } from "@/types/guild.js";
-import logger from "@/utils/logger.js";
+import { defaultCooldownConfig, defaultInterjectionRate, guildConfigs } from "@/config/index";
+import { GuildConfig } from "@/types/guild";
+import logger from "@/utils/logger";
 
 /**
  * Retrieves the effective cooldown configuration for a given guild or DM.

--- a/src/utils/urlExtractor/extractDiscord.ts
+++ b/src/utils/urlExtractor/extractDiscord.ts
@@ -3,9 +3,9 @@
  * @description Captures Discord stickers and attachments, converting them into ChatGPT Blocks.
  */
 
-import { Block } from "@/types/block.js";
-import { stripQuery } from "@/utils/discordHelpers.js";
-import logger from "@/utils/logger.js";
+import { Block } from "@/types/block";
+import { stripQuery } from "@/utils/discordHelpers";
+import logger from "@/utils/logger";
 import { Message } from "discord.js";
 import fetch from "node-fetch";
 

--- a/src/utils/urlExtractor/extractGifs.ts
+++ b/src/utils/urlExtractor/extractGifs.ts
@@ -3,10 +3,10 @@
  * @description Fetches and embeds GIFs from Tenor, Giphy, and Klipy links into ChatGPT Blocks.
  */
 
-import { Block } from "@/types/block.js";
-import { stripQuery } from "@/utils/discordHelpers.js";
-import logger from "@/utils/logger.js";
-import { IMAGE_EXT_RE } from "@/utils/urlExtractor/index.js";
+import { Block } from "@/types/block";
+import { stripQuery } from "@/utils/discordHelpers";
+import logger from "@/utils/logger";
+import { IMAGE_EXT_RE } from "@/utils/urlExtractor/index";
 import { GiphyFetch } from "@giphy/js-fetch-api";
 import { Message } from "discord.js";
 

--- a/src/utils/urlExtractor/extractInlineImages.ts
+++ b/src/utils/urlExtractor/extractInlineImages.ts
@@ -3,9 +3,9 @@
  * @description Scans message content for direct image URLs and inlines or references them as Blocks.
  */
 
-import { Block } from "@/types/block.js";
-import { stripQuery } from "@/utils/discordHelpers.js";
-import logger from "@/utils/logger.js";
+import { Block } from "@/types/block";
+import { stripQuery } from "@/utils/discordHelpers";
+import logger from "@/utils/logger";
 import { Message } from "discord.js";
 
 /**

--- a/src/utils/urlExtractor/extractSocialEmbeds.ts
+++ b/src/utils/urlExtractor/extractSocialEmbeds.ts
@@ -3,10 +3,10 @@
  * @description Processes social media embeds (Twitter, YouTube, Reddit, Instagram, TikTok) into Blocks.
  */
 
-import { Block } from "@/types/block.js";
-import { stripQuery } from "@/utils/discordHelpers.js";
-import logger from "@/utils/logger.js";
-import { IMAGE_EXT_RE } from "@/utils/urlExtractor/index.js";
+import { Block } from "@/types/block";
+import { stripQuery } from "@/utils/discordHelpers";
+import logger from "@/utils/logger";
+import { IMAGE_EXT_RE } from "@/utils/urlExtractor/index";
 import { Message } from "discord.js";
 import sanitizeHtml from "sanitize-html";
 

--- a/src/utils/urlExtractor/index.ts
+++ b/src/utils/urlExtractor/index.ts
@@ -3,17 +3,17 @@
  * @description Parses and normalises Discord message contents into structured ChatGPT Blocks.
  */
 
-import { Block } from "@/types/block.js";
-import { stripQuery } from "@/utils/discordHelpers.js";
-import { getOptional } from "@/utils/env.js";
-import { extractAttachments, extractStickers } from "@/utils/urlExtractor/extractDiscord.js";
+import { Block } from "@/types/block";
+import { stripQuery } from "@/utils/discordHelpers";
+import { getOptional } from "@/utils/env";
+import { extractAttachments, extractStickers } from "@/utils/urlExtractor/extractDiscord";
 import {
   extractGiphyGifs,
   extractKlipyGifs,
   extractTenorGifs,
-} from "@/utils/urlExtractor/extractGifs.js";
-import { extractInlineImages } from "@/utils/urlExtractor/extractInlineImages.js";
-import { extractSocialEmbeds } from "@/utils/urlExtractor/extractSocialEmbeds.js";
+} from "@/utils/urlExtractor/extractGifs";
+import { extractInlineImages } from "@/utils/urlExtractor/extractInlineImages";
+import { extractSocialEmbeds } from "@/utils/urlExtractor/extractSocialEmbeds";
 import { Message } from "discord.js";
 
 /** Recognises image file extensions for inline detection. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "rootDir": "./src",
     "outDir": "./build",
     "strict": true, // enables all strict-mode checks
@@ -26,6 +26,11 @@
       "@/*": ["./src/*"]
     },
     "typeRoots": ["./node_modules/@types", "./src/types"]
+  },
+  // Source imports are extensionless; Node ESM needs real file paths at runtime,
+  // so tsc-alias appends the .js extension when it rewrites the @/* aliases.
+  "tsc-alias": {
+    "resolveFullPaths": true
   },
   "include": ["src"],
   "exclude": ["build", "node_modules", "**/*.spec.ts"]


### PR DESCRIPTION
## Summary

### Internal imports drop the `.js` extension

- every `@/*` specifier across the 32 source files is now extensionless, which `moduleResolution: "Bundler"` already accepts. 102 specifiers in 24 files
- the emitted ESM still needs real file paths, since `build/index.js` is run directly by Node. `tsc-alias` gains `resolveFullPaths`, so it appends `.js` while rewriting the aliases and the build output is byte-for-byte the same shape as before
- bare specifiers keep their extension on purpose: `mathjax-full/js/*.js` are actual files in `node_modules`, not an authored convention, and `discord.js` is a package name. The runtime `.js`/`.ts` picker in `src/index.ts` that chooses which command directory to load from is also untouched
- `src/utils/trimMemory.ts` was already extensionless, so the codebase is now consistent rather than split

### GitHub Actions pins

- `checkout` and `setup-node` move to v7, `github-script` to v9, clearing the runner warning about node20 actions being forced onto node24
- a `github-actions` Dependabot ecosystem now tracks those pins so they do not silently fall behind again

Kept as its own commit since it is unrelated to the import change.

### Other

- bumped version to 2.2.1

## Test plan

- [x] `npm run typecheck`, `npm run lint` and `npm run build` all pass
- [x] scripted check over all 32 emitted files: every relative import in `build/` ends in `.js`, none left extensionless
- [x] imported six compiled modules under Node to prove resolution end to end, including the deep chains through `replyService`, `messageController` and `latexRenderer`. All resolved
- [x] rebuilt after lint-staged reformatted `tsconfig.json`, so the committed config is the one that was verified
- [x] pre-commit (lint-staged + typecheck) and pre-push (lint + build) hooks pass on both commits
- [ ] CI not yet green at time of opening

No behaviour change: this is a source-level convention plus a build-step flag that restores what the compiler previously carried through verbatim.
